### PR TITLE
Provide custom Faraday connection

### DIFF
--- a/lib/mrkt.rb
+++ b/lib/mrkt.rb
@@ -39,6 +39,7 @@ module Mrkt
       @client_id = options.fetch(:client_id)
       @client_secret = options.fetch(:client_secret)
       @max_retries = options.fetch(:max_retries, 10)
+      @connection = options.fetch(:connection, nil)
 
       @options = options
     end

--- a/spec/concerns/connection_spec.rb
+++ b/spec/concerns/connection_spec.rb
@@ -2,7 +2,7 @@ describe Mrkt::Client do
   include_context 'initialized client'
 
   it "uses an existing Faraday connection when provided" do
-    logger_double = instance_double("Rails::Logger", debug: "Debugging", info: "Info")
+    logger_double = instance_double("::Logger", debug: "Debugging", info: "Info")
 
     conn = Faraday.new do |builder|
       builder.response :logger, logger_double

--- a/spec/concerns/connection_spec.rb
+++ b/spec/concerns/connection_spec.rb
@@ -1,0 +1,21 @@
+describe Mrkt::Client do
+  include_context 'initialized client'
+
+  it "uses an existing Faraday connection when provided" do
+    logger_double = instance_double("Rails::Logger", debug: "Debugging", info: "Info")
+
+    conn = Faraday.new do |builder|
+      builder.response :logger, logger_double
+      builder.adapter :test do |stub|
+        stub.get('/ebi') { |env| [ 200, {}, 'shrimp' ]}
+      end
+    end
+
+    client = Mrkt::Client.new(host: host, client_id: client_id, client_secret: client_secret, connection: conn)
+
+    expect(client.connection.get('/ebi').body).to eq('shrimp')
+    expect(logger_double).to have_received(:debug).at_least(:once)
+    expect(logger_double).to have_received(:info).at_least(:once)
+  end
+
+end


### PR DESCRIPTION
Instead of trying to expose every configuration option of Faraday via the `Mrkt::Client` interface this allows the client to accept a pre-configured Faraday connection.

Simplifies customizations for logging, performing retries or adding more middlewares.
