### PR TITLE
Add support for getting activities in bulk

### DIFF
--- a/lib/mrkt/version.rb
+++ b/lib/mrkt/version.rb
@@ -1,3 +1,3 @@
 module Mrkt
-  VERSION = '0.6.2'
+  VERSION = '0.6.3'
 end


### PR DESCRIPTION
Marketo added a [bulk activity extract](http://developers.marketo.com/rest-api/bulk-extract/bulk-activity-extract/) endpoint. Some limitations:

- Can only get activities from one month at a time
- Limits response to a CSV file of max 500 mb